### PR TITLE
Add set_features for controller settings

### DIFF
--- a/drone_mobile/__init__.py
+++ b/drone_mobile/__init__.py
@@ -5,7 +5,7 @@ A Python library for interacting with the DroneMobile API to control
 Firstech/Compustar remote start systems.
 """
 
-__version__ = "0.3.4"
+__version__ = "0.4.0"
 __author__ = "bjhiltbrand"
 
 from .client import DroneMobileClient

--- a/drone_mobile/client.py
+++ b/drone_mobile/client.py
@@ -9,7 +9,9 @@ import requests
 
 from .auth import AuthenticationManager, MFACallback
 from .const import (
+    API_VERSION,
     AVAILABLE_COMMANDS,
+    BASE_API_URL,
     DEFAULT_HEADERS,
     DEFAULT_TIMEOUT,
     DEVICE_TYPE_CONTROLLER,
@@ -308,6 +310,74 @@ class DroneMobileClient:
             APIError: If API request fails
         """
         return self.send_command(device_key, "DEVICE_STATUS", DEVICE_TYPE_CONTROLLER)
+
+    def set_features(
+        self,
+        vehicle_id: str,
+        features: Dict[str, bool],
+        _retry: bool = True,
+    ) -> Dict:
+        """
+        Update controller feature settings for a vehicle.
+
+        The DroneMobile app manages settings such as the siren, valet mode,
+        shock sensor, drive lock, turbo timer, and passive arming through a
+        single features resource. The API expects the full feature object, so
+        callers should send every known flag with the desired ones changed.
+
+        Args:
+            vehicle_id: The vehicle's id (the same id used elsewhere; it keys
+                the device features endpoint).
+            features: Mapping of feature flag to desired bool, for example
+                ``{"siren_enabled": True}``.
+            _retry: Internal flag - set to False after a single token-refresh
+                retry to prevent infinite recursion on repeated 401s.
+
+        Returns:
+            The updated features as returned by the API.
+
+        Raises:
+            AuthenticationError: If token refresh does not resolve a 401
+            RateLimitError: If the API rate limit is exceeded
+            APIError: If the API request fails
+            NetworkError: If the network request fails
+        """
+        _LOGGER.debug(f"Updating features for vehicle {vehicle_id}: {features}")
+
+        headers = {**DEFAULT_HEADERS, **self.auth.get_auth_headers()}
+        url = f"{BASE_API_URL}{API_VERSION}/device/{vehicle_id}/features"
+
+        try:
+            response = self._session.patch(
+                url,
+                json=features,
+                headers=headers,
+                timeout=DEFAULT_TIMEOUT,
+            )
+        except requests.exceptions.RequestException as e:
+            raise NetworkError(f"Network error updating features: {e}") from e
+
+        if response.status_code == 200:
+            return response.json() if response.content else {}
+        elif response.status_code == 401:
+            if not _retry:
+                raise AuthenticationError(
+                    "Token refresh did not resolve 401 on set_features. "
+                    "The account may be suspended or the API credentials revoked."
+                )
+            _LOGGER.debug("Token expired, refreshing and retrying")
+            self.auth.authenticate(force_refresh=True)
+            return self.set_features(vehicle_id, features, _retry=False)
+        elif response.status_code == 429:
+            raise RateLimitError(
+                "API rate limit exceeded", response.status_code, response.json()
+            )
+        else:
+            raise APIError(
+                f"Failed to update features: {response.text}",
+                response.status_code,
+                response.json() if response.content else None,
+            )
 
     def close(self) -> None:
         """Close the HTTP session."""

--- a/drone_mobile/vehicle.py
+++ b/drone_mobile/vehicle.py
@@ -213,6 +213,32 @@ class Vehicle:
         _LOGGER.info(f"Requesting location for {self.name}")
         return self._client.send_command(self.device_key, "LOCATION")
 
+    def set_features(self, **features: bool) -> dict:
+        """
+        Update controller feature settings (siren, valet mode, shock sensor,
+        drive lock, turbo timer, passive arming).
+
+        The API expects the complete feature object, so pass every known flag
+        with the ones you want to change set accordingly, for example::
+
+            vehicle.set_features(
+                siren_enabled=True,
+                valet_mode_enabled=False,
+                shock_sensor_enabled=True,
+                drive_lock_enabled=False,
+                turbo_timer_start_enabled=False,
+                passive_arming_enabled=False,
+            )
+
+        Returns:
+            The updated features dict from the API.
+
+        Raises:
+            APIError: If the API request fails
+        """
+        _LOGGER.info(f"Updating features for {self.name}: {features}")
+        return self._client.set_features(self.vehicle_id, features)
+
     def __repr__(self) -> str:
         """String representation of the vehicle."""
         return (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "drone_mobile"
-version = "0.3.4"
+version = "0.4.0"
 description = "Python wrapper for the DroneMobile API for Firstech/Compustar remote start systems."
 readme = "README.md"
 authors = [

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -89,6 +89,25 @@ class TestDroneMobileClient:
 
         assert len(vehicles) == 0
 
+    @patch("drone_mobile.client.requests.Session.patch")
+    def test_set_features_success(self, mock_patch, client, mock_auth):
+        """Test updating controller feature settings."""
+        client.auth = mock_auth
+
+        updated = {"siren_enabled": True, "valet_mode_enabled": False}
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.content = b"{}"
+        mock_response.json.return_value = updated
+        mock_patch.return_value = mock_response
+
+        result = client.set_features("30611339962", {"siren_enabled": True})
+
+        assert result == updated
+        args, kwargs = mock_patch.call_args
+        assert args[0].endswith("/device/30611339962/features")
+        assert kwargs["json"] == {"siren_enabled": True}
+
     @patch("drone_mobile.client.requests.Session.get")
     def test_get_vehicles_rate_limit(self, mock_get, client, mock_auth):
         """Test rate limit error when getting vehicles."""


### PR DESCRIPTION
## Summary

Adds support for controller **feature settings**, which the DroneMobile app manages through a separate REST resource from the command endpoint:

`PATCH https://api.dronemobile.com/api/v1/device/{vehicle_id}/features`

with the full feature object as the body, for example:

```json
{"siren_enabled": true, "valet_mode_enabled": false, "shock_sensor_enabled": true, "drive_lock_enabled": false, "turbo_timer_start_enabled": false, "passive_arming_enabled": false}
```

This is distinct from `POST /iot/command` (the whitelisted commands like ARM/TRUNK), so it needs its own method.

## Changes
- `Client.set_features(vehicle_id, features)`: PATCHes the features resource, reusing the existing auth headers, timeout, and 401 refresh-retry pattern. The endpoint is keyed by the vehicle `id` (the same id used elsewhere).
- `Vehicle.set_features(**features)`: thin wrapper.
- Unit test for the success path (asserts the URL and JSON body).

The API expects the complete feature object, so callers send all known flags with the changed ones set.

## Notes
- Endpoint and body verified from a live capture: toggling Siren in the web app sends exactly this PATCH.
- Opening as a draft pending a live round-trip against a real vehicle.
- Unrelated heads-up: `test_get_vehicle_status_success` fails on a clean checkout of `main` as well (the fixture uses `vehicle_id` while `get_vehicle_status` matches on `id`). Not touched here.

## Why
Unblocks exposing the controller-setting toggles (siren, valet, shock sensor, drive lock, turbo timer, passive arming) as switches in the Home Assistant integration.