### PR TITLE
Device remembering: stop periodic MFA re-authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,37 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- **Device remembering** so accounts with MFA enabled are no longer forced back
+  through a second factor every few hours. After an MFA login the device is
+  confirmed and remembered with Cognito (`ConfirmDevice` + `UpdateDeviceStatus`),
+  and once the refresh token expires the library re-authenticates with the
+  remembered device via the `DEVICE_SRP_AUTH` / `DEVICE_PASSWORD_VERIFIER`
+  challenge, with no MFA prompt.
+- `drone_mobile/device_srp.py`: device SRP helpers (`generate_device_verifier`,
+  `DeviceSRP`, `cognito_timestamp`) implementing the Cognito device SRP scheme.
+- A `device.json` file persisted next to `token.json` holding the remembered
+  `DeviceKey`, `DeviceGroupKey` and device password (mode `600`).
+- Tests: a self-contained SRP round trip (`tests/test_device_srp.py`) and the
+  full remember / device-SRP / fallback flow (`tests/test_device_remembering.py`).
+
+### Changed
+- The MFA challenge response now echoes the user pool's internal username
+  (`USER_ID_FOR_SRP`, i.e. the `sub`) instead of the email alias. Without this,
+  the resulting access token cannot call `ConfirmDevice` (Cognito rejects it
+  with "Invalid device key given"), which silently breaks device remembering.
+  Pools that omit the parameter fall back to the configured username, so
+  SMS-only setups are unaffected.
+- `REFRESH_TOKEN_AUTH` and the full `USER_PASSWORD_AUTH` login now include
+  `DEVICE_KEY` when a device has been remembered, so Cognito offers the device
+  challenge instead of MFA.
+
+### Fixed
+- Accounts with optional / authenticator-app MFA no longer drop offline every
+  few hours once the Cognito refresh token expires.
+
 ## [0.3.4] - 2026-04-10
 
 ### Added

--- a/drone_mobile/__init__.py
+++ b/drone_mobile/__init__.py
@@ -5,7 +5,7 @@ A Python library for interacting with the DroneMobile API to control
 Firstech/Compustar remote start systems.
 """
 
-__version__ = "0.4.0"
+__version__ = "0.5.0.dev0"
 __author__ = "bjhiltbrand"
 
 from .client import DroneMobileClient

--- a/drone_mobile/__init__.py
+++ b/drone_mobile/__init__.py
@@ -5,7 +5,7 @@ A Python library for interacting with the DroneMobile API to control
 Firstech/Compustar remote start systems.
 """
 
-__version__ = "0.5.0.dev0"
+__version__ = "0.5.0.dev1"
 __author__ = "bjhiltbrand"
 
 from .client import DroneMobileClient

--- a/drone_mobile/auth.py
+++ b/drone_mobile/auth.py
@@ -25,6 +25,7 @@ from .const import (
     TOKEN_EXPIRY_MARGIN,
     URLS,
 )
+from .device_srp import generate_device_verifier
 from .exceptions import (
     AuthenticationError,
     InvalidCredentialsError,
@@ -89,8 +90,10 @@ class AuthenticationManager:
         self.password = password
         self.token_dir = token_dir or DEFAULT_TOKEN_DIR
         self.token_file = self.token_dir / token_file
+        self.device_file = self.token_dir / "device.json"
         self.mfa_callback = mfa_callback
         self._token: AuthToken | None = None
+        self._device: dict | None = None
         self._lock = threading.Lock()
 
         # Set secure permissions on token directory.
@@ -371,12 +374,15 @@ class AuthenticationManager:
 
         _LOGGER.debug("Refreshing access token")
 
+        auth_params = {"REFRESH_TOKEN": self._token.refresh_token}
+        device = self._load_device()
+        if device and device.get("DeviceKey"):
+            auth_params["DEVICE_KEY"] = device["DeviceKey"]
+
         payload = {
             "AuthFlow": "REFRESH_TOKEN_AUTH",
             "ClientId": AWS_CLIENT_ID,
-            "AuthParameters": {
-                "REFRESH_TOKEN": self._token.refresh_token,
-            },
+            "AuthParameters": auth_params,
         }
 
         headers = {**DEFAULT_HEADERS, **AUTH_HEADERS}
@@ -417,6 +423,99 @@ class AuthenticationManager:
             )
 
     # ------------------------------------------------------------------
+    # Private helpers – device remembering
+    # ------------------------------------------------------------------
+
+    def _cognito_request(self, target: str, payload: dict) -> dict:
+        """Make a raw Cognito IdP API call (e.g. ConfirmDevice)."""
+        headers = {
+            **DEFAULT_HEADERS,
+            "Content-Type": "application/x-amz-json-1.1",
+            "X-Amz-Target": f"AWSCognitoIdentityProviderService.{target}",
+            "X-Amz-User-Agent": "aws-amplify/5.0.4 js",
+            "Referer": "https://accounts.dronemobile.com/",
+        }
+        try:
+            response = requests.post(
+                URLS["auth"], json=payload, headers=headers, timeout=DEFAULT_TIMEOUT
+            )
+        except requests.exceptions.RequestException as e:
+            raise NetworkError(f"Network error during {target}: {e}") from e
+        if response.status_code != 200:
+            raise AuthenticationError(
+                f"{target} failed with status {response.status_code}: {response.text}"
+            )
+        return response.json() if response.content else {}
+
+    def _remember_device(
+        self, access_token: str, device_key: str, device_group_key: str
+    ) -> None:
+        """Confirm and remember a newly-issued Cognito device.
+
+        Replicates the app's "Don't ask again on this device": generate a device
+        password verifier, ``ConfirmDevice``, then mark it remembered. The
+        DeviceKey is afterwards included on refresh so refreshes are not forced
+        through MFA.
+        """
+        existing = self._load_device()
+        if existing and existing.get("DeviceKey") == device_key:
+            return
+
+        device_password, verifier_config = generate_device_verifier(
+            device_group_key, device_key
+        )
+        self._cognito_request(
+            "ConfirmDevice",
+            {
+                "AccessToken": access_token,
+                "DeviceKey": device_key,
+                "DeviceName": "Home Assistant",
+                "DeviceSecretVerifierConfig": verifier_config,
+            },
+        )
+        self._cognito_request(
+            "UpdateDeviceStatus",
+            {
+                "AccessToken": access_token,
+                "DeviceKey": device_key,
+                "DeviceRememberedStatus": "remembered",
+            },
+        )
+        self._device = {
+            "DeviceKey": device_key,
+            "DeviceGroupKey": device_group_key,
+            "DevicePassword": device_password,
+        }
+        self._save_device()
+        _LOGGER.info("Device confirmed and remembered (DeviceKey=%s)", device_key)
+
+    def _save_device(self) -> None:
+        """Persist the remembered device next to the token."""
+        if not self._device:
+            return
+        try:
+            with open(self.device_file, "w") as f:
+                json.dump(self._device, f, indent=2)
+            try:
+                os.chmod(self.device_file, 0o600)
+            except OSError:
+                pass
+        except OSError as e:
+            _LOGGER.warning(f"Could not save device file: {e}")
+
+    def _load_device(self) -> dict | None:
+        """Load the remembered device from disk (cached in memory)."""
+        if self._device is not None:
+            return self._device
+        if self.device_file.exists():
+            try:
+                with open(self.device_file) as f:
+                    self._device = json.load(f)
+            except (json.JSONDecodeError, OSError) as e:
+                _LOGGER.warning(f"Could not load device file: {e}")
+        return self._device
+
+    # ------------------------------------------------------------------
     # Private helpers – token persistence
     # ------------------------------------------------------------------
 
@@ -431,6 +530,22 @@ class AuthenticationManager:
             AuthToken object
         """
         auth_result = response["AuthenticationResult"]
+
+        # If Cognito issued a device for this fresh login, confirm and remember
+        # it so subsequent refreshes are not forced back through MFA.
+        ndm = auth_result.get("NewDeviceMetadata")
+        if ndm and ndm.get("DeviceKey"):
+            try:
+                self._remember_device(
+                    auth_result["AccessToken"],
+                    ndm["DeviceKey"],
+                    ndm.get("DeviceGroupKey", ""),
+                )
+            except Exception as e:  # noqa: BLE001 - never block login on this
+                _LOGGER.warning(
+                    "Could not remember device (will rely on refresh token): %s", e
+                )
+
         expires_in = auth_result["ExpiresIn"]
         expires_at = datetime.now() + timedelta(seconds=expires_in - TOKEN_EXPIRY_MARGIN)
 

--- a/drone_mobile/auth.py
+++ b/drone_mobile/auth.py
@@ -25,7 +25,7 @@ from .const import (
     TOKEN_EXPIRY_MARGIN,
     URLS,
 )
-from .device_srp import generate_device_verifier
+from .device_srp import DeviceSRP, cognito_timestamp, generate_device_verifier
 from .exceptions import (
     AuthenticationError,
     InvalidCredentialsError,
@@ -191,13 +191,19 @@ class AuthenticationManager:
         """
         _LOGGER.debug("Performing new authentication")
 
+        auth_params = {"USERNAME": self.username, "PASSWORD": self.password}
+
+        # If this device has been confirmed and remembered, pass its key so
+        # Cognito issues a DEVICE_SRP_AUTH challenge (which we can answer
+        # unattended) instead of forcing a second factor.
+        device = self._load_device()
+        if device and device.get("DeviceKey"):
+            auth_params["DEVICE_KEY"] = device["DeviceKey"]
+
         payload = {
             "AuthFlow": "USER_PASSWORD_AUTH",
             "ClientId": AWS_CLIENT_ID,
-            "AuthParameters": {
-                "USERNAME": self.username,
-                "PASSWORD": self.password,
-            },
+            "AuthParameters": auth_params,
             "ClientMetadata": {},
         }
 
@@ -216,8 +222,12 @@ class AuthenticationManager:
         if response.status_code == 200:
             result = response.json()
 
-            # Cognito may return a challenge instead of tokens when MFA is enabled.
-            if "ChallengeName" in result:
+            # Cognito may return a challenge instead of tokens.
+            challenge_name = result.get("ChallengeName")
+            if challenge_name == "DEVICE_SRP_AUTH":
+                # Remembered device: authenticate via device SRP, no MFA needed.
+                return self._respond_to_device_srp(result)
+            if challenge_name:
                 return self._respond_to_mfa_challenge(result)
 
             self._token = self._parse_auth_response(result)
@@ -305,12 +315,20 @@ class AuthenticationManager:
         # Map challenge name to the correct ChallengeResponse key.
         code_key = "SMS_MFA_CODE" if challenge_name == "SMS_MFA" else "SOFTWARE_TOKEN_MFA_CODE"
 
+        # Cognito requires the user pool's *internal* username here (the
+        # ``USER_ID_FOR_SRP`` it handed back, i.e. the sub), not the email alias.
+        # Echoing the email still yields tokens, but those tokens then cannot
+        # call ConfirmDevice ("Invalid device key given"), which silently breaks
+        # device remembering. Falling back to self.username keeps SMS-only pools
+        # that omit the parameter working.
+        srp_username = params.get("USER_ID_FOR_SRP") or self.username
+
         payload = {
             "ChallengeName": challenge_name,
             "ClientId": AWS_CLIENT_ID,
             "Session": session,
             "ChallengeResponses": {
-                "USERNAME": self.username,
+                "USERNAME": srp_username,
                 code_key: cleaned_code,
             },
         }
@@ -356,6 +374,91 @@ class AuthenticationManager:
             raise AuthenticationError(
                 f"MFA challenge failed with status {response.status_code}: {response.text}"
             )
+
+    def _respond_to_device_srp(self, challenge: dict) -> AuthToken:
+        """Authenticate a remembered device via Cognito's device SRP exchange.
+
+        When a device has been confirmed and remembered, Cognito issues a
+        ``DEVICE_SRP_AUTH`` challenge instead of an MFA challenge. We answer it
+        with the stored device password (a two-step SRP handshake:
+        ``DEVICE_SRP_AUTH`` -> ``DEVICE_PASSWORD_VERIFIER``), which lets the
+        integration re-authenticate without a second factor after the refresh
+        token expires.
+
+        Raises:
+            AuthenticationError: If no device secret is stored or the handshake
+                is rejected (the stale device is cleared so the next attempt
+                falls back to a clean login).
+            NetworkError: If an HTTP request fails.
+        """
+        device = self._load_device()
+        if not device or not device.get("DevicePassword"):
+            raise AuthenticationError(
+                "Cognito requested DEVICE_SRP_AUTH but no remembered device "
+                "secret is stored; a fresh login is required."
+            )
+
+        device_key = device["DeviceKey"]
+        username = (
+            challenge.get("ChallengeParameters", {}).get("USERNAME") or self.username
+        )
+        srp = DeviceSRP(device["DeviceGroupKey"], device_key, device["DevicePassword"])
+
+        try:
+            # Step 1: send the client SRP public value (SRP_A).
+            srp_payload = {
+                "ChallengeName": "DEVICE_SRP_AUTH",
+                "ClientId": AWS_CLIENT_ID,
+                "ChallengeResponses": {
+                    "USERNAME": username,
+                    "DEVICE_KEY": device_key,
+                    "SRP_A": srp.srp_a,
+                },
+            }
+            if challenge.get("Session"):
+                srp_payload["Session"] = challenge["Session"]
+            verifier = self._cognito_request("RespondToAuthChallenge", srp_payload)
+
+            if verifier.get("ChallengeName") != "DEVICE_PASSWORD_VERIFIER":
+                raise AuthenticationError(
+                    "Unexpected challenge after DEVICE_SRP_AUTH: "
+                    f"{verifier.get('ChallengeName')}"
+                )
+
+            # Step 2: prove possession of the device password.
+            cp = verifier["ChallengeParameters"]
+            timestamp = cognito_timestamp()
+            signature = srp.process_challenge(
+                cp["SRP_B"], cp["SALT"], cp["SECRET_BLOCK"], timestamp
+            )
+            verify_payload = {
+                "ChallengeName": "DEVICE_PASSWORD_VERIFIER",
+                "ClientId": AWS_CLIENT_ID,
+                "ChallengeResponses": {
+                    "USERNAME": username,
+                    "DEVICE_KEY": device_key,
+                    "TIMESTAMP": timestamp,
+                    "PASSWORD_CLAIM_SECRET_BLOCK": cp["SECRET_BLOCK"],
+                    "PASSWORD_CLAIM_SIGNATURE": signature,
+                },
+            }
+            if verifier.get("Session"):
+                verify_payload["Session"] = verifier["Session"]
+            result = self._cognito_request("RespondToAuthChallenge", verify_payload)
+        except AuthenticationError:
+            # The remembered device is no longer usable (revoked, rotated, or a
+            # bad secret). Drop it so the next attempt does a clean MFA login.
+            _LOGGER.warning(
+                "Device SRP login failed; clearing remembered device so the next "
+                "login starts fresh."
+            )
+            self._clear_device()
+            raise
+
+        self._token = self._parse_auth_response(result)
+        self._save_token(self._token)
+        _LOGGER.info("Authenticated via remembered device (MFA skipped)")
+        return self._token
 
     def _refresh_token(self) -> AuthToken:
         """
@@ -514,6 +617,15 @@ class AuthenticationManager:
             except (json.JSONDecodeError, OSError) as e:
                 _LOGGER.warning(f"Could not load device file: {e}")
         return self._device
+
+    def _clear_device(self) -> None:
+        """Forget the remembered device (in memory and on disk)."""
+        self._device = None
+        try:
+            if self.device_file.exists():
+                self.device_file.unlink()
+        except OSError as e:
+            _LOGGER.debug(f"Could not remove device file: {e}")
 
     # ------------------------------------------------------------------
     # Private helpers – token persistence

--- a/drone_mobile/device_srp.py
+++ b/drone_mobile/device_srp.py
@@ -12,7 +12,9 @@ This mirrors the AWS Cognito device SRP scheme (the same math used by
 from __future__ import annotations
 
 import base64
+import datetime
 import hashlib
+import hmac
 import os
 
 # 3072-bit group used by Cognito SRP.
@@ -75,3 +77,106 @@ def generate_device_verifier(device_group_key: str, device_key: str):
         ).decode("utf-8"),
         "Salt": base64.standard_b64encode(bytes.fromhex(salt_hex)).decode("utf-8"),
     }
+
+
+# ---------------------------------------------------------------------------
+# Device SRP authentication (DEVICE_SRP_AUTH / DEVICE_PASSWORD_VERIFIER)
+# ---------------------------------------------------------------------------
+#
+# Once a device is confirmed and "remembered", Cognito offers a DEVICE_SRP_AUTH
+# challenge in place of MFA on subsequent logins. Answering it with the device
+# password lets the integration re-authenticate unattended (no second factor),
+# which is what keeps the connection alive after the refresh token expires.
+
+# SRP-6a multiplier parameter: k = H(N | PAD(g)).
+_K = int(_sha256_hex(bytes.fromhex("00" + _N_HEX + "0" + format(_G, "x"))), 16)
+_DERIVED_KEY_INFO = b"Caldera Derived Key"
+
+
+def _hex_hash(hex_str: str) -> str:
+    """SHA-256 of the bytes a hex string represents, returned as hex."""
+    return _sha256_hex(bytes.fromhex(hex_str))
+
+
+def _hkdf(ikm: bytes, salt: bytes) -> bytes:
+    """Cognito's HKDF: extract with ``salt``, expand to a 16-byte key."""
+    prk = hmac.new(salt, ikm, hashlib.sha256).digest()
+    return hmac.new(prk, _DERIVED_KEY_INFO + b"\x01", hashlib.sha256).digest()[:16]
+
+
+def cognito_timestamp() -> str:
+    """Timestamp in the exact format Cognito's SRP signature expects.
+
+    e.g. ``"Tue Jun 5 09:08:07 UTC 2026"`` (English, UTC, day NOT zero-padded).
+    The day must not be zero-padded or the signature check fails.
+    """
+    days = ("Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun")
+    months = (
+        "Jan", "Feb", "Mar", "Apr", "May", "Jun",
+        "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
+    )
+    now = datetime.datetime.now(datetime.timezone.utc)
+    return "%s %s %d %02d:%02d:%02d UTC %d" % (
+        days[now.weekday()], months[now.month - 1], now.day,
+        now.hour, now.minute, now.second, now.year,
+    )
+
+
+class DeviceSRP:
+    """Client side of Cognito's device SRP exchange.
+
+    Usage::
+
+        srp = DeviceSRP(device_group_key, device_key, device_password)
+        # answer DEVICE_SRP_AUTH with srp.srp_a, then for DEVICE_PASSWORD_VERIFIER:
+        ts = cognito_timestamp()
+        sig = srp.process_challenge(srp_b, salt, secret_block, ts)
+    """
+
+    def __init__(self, device_group_key: str, device_key: str, device_password: str):
+        self.device_group_key = device_group_key
+        self.device_key = device_key
+        self.device_password = device_password
+        self._small_a = int.from_bytes(os.urandom(128), "big") % _BIG_N
+        self._large_a = pow(_G, self._small_a, _BIG_N)
+
+    @property
+    def srp_a(self) -> str:
+        """Client public value ``A`` as hex (the ``SRP_A`` challenge parameter)."""
+        return format(self._large_a, "x")
+
+    def process_challenge(
+        self, srp_b_hex: str, salt_hex: str, secret_block: str, timestamp: str
+    ) -> str:
+        """Compute ``PASSWORD_CLAIM_SIGNATURE`` for DEVICE_PASSWORD_VERIFIER.
+
+        Args:
+            srp_b_hex: server public value ``SRP_B`` (hex) from the challenge.
+            salt_hex: ``SALT`` (hex) from the challenge.
+            secret_block: ``SECRET_BLOCK`` (base64) from the challenge.
+            timestamp: the value also returned as ``TIMESTAMP``; must come from
+                :func:`cognito_timestamp` (the signature is over it).
+        """
+        big_b = int(srp_b_hex, 16)
+        if big_b % _BIG_N == 0:
+            raise ValueError("Bad server SRP_B value (B mod N == 0)")
+        u = int(_hex_hash(_pad_hex(self._large_a) + _pad_hex(big_b)), 16)
+        if u == 0:
+            raise ValueError("Bad SRP U value (U == 0)")
+
+        full_password = f"{self.device_group_key}{self.device_key}:{self.device_password}"
+        full_password_hash = _sha256_hex(full_password.encode("utf-8"))
+        x = int(_hex_hash(_pad_hex(salt_hex) + full_password_hash), 16)
+
+        s = pow((big_b - _K * pow(_G, x, _BIG_N)) % _BIG_N, self._small_a + u * x, _BIG_N)
+        key = _hkdf(bytes.fromhex(_pad_hex(s)), bytes.fromhex(_pad_hex(u)))
+
+        message = (
+            self.device_group_key.encode("utf-8")
+            + self.device_key.encode("utf-8")
+            + base64.standard_b64decode(secret_block)
+            + timestamp.encode("utf-8")
+        )
+        return base64.standard_b64encode(
+            hmac.new(key, message, hashlib.sha256).digest()
+        ).decode("utf-8")

--- a/drone_mobile/device_srp.py
+++ b/drone_mobile/device_srp.py
@@ -1,0 +1,77 @@
+"""Device SRP helper for Cognito "remember this device".
+
+Generates the password verifier sent to ``ConfirmDevice`` so the DroneMobile
+Cognito user pool will remember this device. A remembered device lets token
+refreshes succeed without falling back to a full (MFA) login, which is what
+otherwise forces re-authentication every few hours.
+
+This mirrors the AWS Cognito device SRP scheme (the same math used by
+``pycognito`` / ``warrant``).
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import os
+
+# 3072-bit group used by Cognito SRP.
+_N_HEX = (
+    "FFFFFFFFFFFFFFFFC90FDAA22168C234C4C6628B80DC1CD1"
+    "29024E088A67CC74020BBEA63B139B22514A08798E3404DD"
+    "EF9519B3CD3A431B302B0A6DF25F14374FE1356D6D51C245"
+    "E485B576625E7EC6F44C42E9A637ED6B0BFF5CB6F406B7ED"
+    "EE386BFB5A899FA5AE9F24117C4B1FE649286651ECE45B3D"
+    "C2007CB8A163BF0598DA48361C55D39A69163FA8FD24CF5F"
+    "83655D23DCA3AD961C62F356208552BB9ED529077096966D"
+    "670C354E4ABC9804F1746C08CA18217C32905E462E36CE3B"
+    "E39E772C180E86039B2783A2EC07A28FB5C55DF06F4C52C9"
+    "DE2BCBF6955817183995497CEA956AE515D2261898FA0510"
+    "15728E5A8AAAC42DAD33170D04507A33A85521ABDF1CBA64"
+    "ECFB850458DBEF0A8AEA71575D060C7DB3970F85A6E1E4C7"
+    "ABF5AE8CDB0933D71E8C94E04A25619DCEE3D2261AD2EE6B"
+    "F12FFA06D98A0864D87602733EC86A64521F2B18177B200C"
+    "BBE117577A615D6C770988C0BAD946E208E24FA074E5AB31"
+    "43DB5BFCE0FD108E4B82D120A93AD2CAFFFFFFFFFFFFFFFF"
+)
+_BIG_N = int(_N_HEX, 16)
+_G = 2
+
+
+def _sha256_hex(data: bytes) -> str:
+    """SHA-256 hex digest (always 64 chars)."""
+    return hashlib.sha256(data).hexdigest()
+
+
+def _pad_hex(value) -> str:
+    """Hex-encode an int (or normalise a hex string) the Cognito way:
+    even length, with a leading ``00`` byte when the top bit is set."""
+    h = format(value, "x") if isinstance(value, int) else value
+    if len(h) % 2 == 1:
+        h = "0" + h
+    elif h[0] in "89abcdefABCDEF":
+        h = "00" + h
+    return h
+
+
+def generate_device_verifier(device_group_key: str, device_key: str):
+    """Build the ConfirmDevice secret for a new device.
+
+    Returns ``(device_password, {"PasswordVerifier": ..., "Salt": ...})``.
+    The password must be kept (it identifies the remembered device); the
+    verifier config is sent to Cognito's ``ConfirmDevice``.
+    """
+    device_password = base64.standard_b64encode(os.urandom(40)).decode("utf-8")
+    full_password = f"{device_group_key}{device_key}:{device_password}"
+    full_password_hash = _sha256_hex(full_password.encode("utf-8"))
+
+    salt_hex = _pad_hex(int.from_bytes(os.urandom(16), "big"))
+    x = int(_sha256_hex(bytes.fromhex(salt_hex + full_password_hash)), 16)
+    verifier_hex = _pad_hex(pow(_G, x, _BIG_N))
+
+    return device_password, {
+        "PasswordVerifier": base64.standard_b64encode(
+            bytes.fromhex(verifier_hex)
+        ).decode("utf-8"),
+        "Salt": base64.standard_b64encode(bytes.fromhex(salt_hex)).decode("utf-8"),
+    }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "drone_mobile"
-version = "0.5.0.dev0"
+version = "0.5.0.dev1"
 description = "Python wrapper for the DroneMobile API for Firstech/Compustar remote start systems."
 readme = "README.md"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "drone_mobile"
-version = "0.4.0"
+version = "0.5.0.dev0"
 description = "Python wrapper for the DroneMobile API for Firstech/Compustar remote start systems."
 readme = "README.md"
 authors = [

--- a/tests/test_device_remembering.py
+++ b/tests/test_device_remembering.py
@@ -8,6 +8,7 @@ Covers the three pieces of the fix:
     rejected handshake clears the stale device.
 """
 
+import base64
 import json
 from datetime import datetime, timedelta
 from unittest.mock import Mock, patch
@@ -166,10 +167,12 @@ def test_confirm_failure_does_not_break_login(mock_post, tmp_path, totp_challeng
 
 
 def _seed_device(auth):
+    # Computed at runtime from obvious plaintext so no secret-looking literal
+    # ends up in the source (the value is meaningless test data).
     auth._device = {
         "DeviceKey": "us-east-1_dev-1",
         "DeviceGroupKey": "-grp1",
-        "DevicePassword": "ZGV2aWNlLXBhc3N3b3Jk",
+        "DevicePassword": base64.b64encode(b"unit-test-device-password").decode(),
     }
     auth._save_device()
 
@@ -206,7 +209,7 @@ def test_device_srp_login_skips_mfa(mock_post, tmp_path, plain_tokens):
         "ChallengeParameters": {
             "SRP_B": format((_BIG_N // 2) + 1234567, "x"),
             "SALT": "0a1b2c3d",
-            "SECRET_BLOCK": "c2VjcmV0LWJsb2Nr",
+            "SECRET_BLOCK": base64.b64encode(b"unit-test-secret-block").decode(),
         },
     }
     mock_post.side_effect = [

--- a/tests/test_device_remembering.py
+++ b/tests/test_device_remembering.py
@@ -1,0 +1,286 @@
+"""Tests for Cognito device remembering (skip MFA on re-authentication).
+
+Covers the three pieces of the fix:
+  * the MFA challenge response echoes the pool's internal username
+    (USER_ID_FOR_SRP), not the email alias, so the token can call ConfirmDevice;
+  * a successful MFA login confirms + remembers the device and persists it;
+  * a remembered device re-authenticates via DEVICE_SRP_AUTH with no MFA, and a
+    rejected handshake clears the stale device.
+"""
+
+import json
+from datetime import datetime, timedelta
+from unittest.mock import Mock, patch
+
+import pytest
+
+from drone_mobile.auth import AuthenticationManager
+from drone_mobile.device_srp import _BIG_N
+from drone_mobile.exceptions import AuthenticationError
+from drone_mobile.models import AuthToken
+
+
+def _resp(status, payload):
+    m = Mock()
+    m.status_code = status
+    m.json.return_value = payload
+    return m
+
+
+def _fail_mfa(_challenge):  # pragma: no cover - only called on failure
+    raise AssertionError("mfa_callback must not be called for a remembered device")
+
+
+@pytest.fixture
+def totp_challenge_sub():
+    """TOTP challenge where the internal username (sub) differs from the email."""
+    return {
+        "ChallengeName": "SOFTWARE_TOKEN_MFA",
+        "Session": "sess-1",
+        "ChallengeParameters": {"USER_ID_FOR_SRP": "sub-uuid-123"},
+    }
+
+
+@pytest.fixture
+def tokens_with_device():
+    return {
+        "AuthenticationResult": {
+            "AccessToken": "at",
+            "IdToken": "it",
+            "RefreshToken": "rt",
+            "TokenType": "Bearer",
+            "ExpiresIn": 3600,
+            "NewDeviceMetadata": {
+                "DeviceKey": "us-east-1_dev-1",
+                "DeviceGroupKey": "-grp1",
+            },
+        }
+    }
+
+
+@pytest.fixture
+def plain_tokens():
+    return {
+        "AuthenticationResult": {
+            "AccessToken": "at",
+            "IdToken": "it",
+            "RefreshToken": "rt",
+            "TokenType": "Bearer",
+            "ExpiresIn": 3600,
+        }
+    }
+
+
+# ---------------------------------------------------------------------------
+# Username fix
+# ---------------------------------------------------------------------------
+
+
+@patch("drone_mobile.auth.requests.post")
+def test_mfa_response_uses_internal_username(mock_post, tmp_path, totp_challenge_sub, plain_tokens):
+    """The challenge response must echo USER_ID_FOR_SRP, not the email."""
+    mock_post.side_effect = [_resp(200, totp_challenge_sub), _resp(200, plain_tokens)]
+    auth = AuthenticationManager(
+        "user@example.com", "pw", token_dir=tmp_path, mfa_callback=lambda _c: "123456"
+    )
+
+    auth.authenticate()
+
+    challenge_payload = mock_post.call_args_list[1].kwargs["json"]
+    assert challenge_payload["ChallengeResponses"]["USERNAME"] == "sub-uuid-123"
+
+
+@patch("drone_mobile.auth.requests.post")
+def test_mfa_username_falls_back_to_email(mock_post, tmp_path, plain_tokens):
+    """When the pool omits USER_ID_FOR_SRP, fall back to the configured username."""
+    challenge = {"ChallengeName": "SMS_MFA", "Session": "s", "ChallengeParameters": {}}
+    mock_post.side_effect = [_resp(200, challenge), _resp(200, plain_tokens)]
+    auth = AuthenticationManager(
+        "user@example.com", "pw", token_dir=tmp_path, mfa_callback=lambda _c: "123456"
+    )
+
+    auth.authenticate()
+
+    challenge_payload = mock_post.call_args_list[1].kwargs["json"]
+    assert challenge_payload["ChallengeResponses"]["USERNAME"] == "user@example.com"
+
+
+# ---------------------------------------------------------------------------
+# Confirm + remember
+# ---------------------------------------------------------------------------
+
+
+@patch("drone_mobile.auth.requests.post")
+def test_device_confirmed_and_remembered(mock_post, tmp_path, totp_challenge_sub, tokens_with_device):
+    mock_post.side_effect = [
+        _resp(200, totp_challenge_sub),                  # InitiateAuth -> challenge
+        _resp(200, tokens_with_device),                  # RespondToAuthChallenge -> tokens + device
+        _resp(200, {"UserConfirmationNecessary": True}),  # ConfirmDevice
+        _resp(200, {}),                                   # UpdateDeviceStatus
+    ]
+    auth = AuthenticationManager(
+        "user@example.com", "pw", token_dir=tmp_path, mfa_callback=lambda _c: "123456"
+    )
+
+    auth.authenticate()
+
+    # Persisted device file with the key, group key and a generated password.
+    assert auth.device_file.exists()
+    saved = json.loads(auth.device_file.read_text())
+    assert saved["DeviceKey"] == "us-east-1_dev-1"
+    assert saved["DeviceGroupKey"] == "-grp1"
+    assert saved["DevicePassword"]
+
+    # ConfirmDevice carried the verifier and targeted the right Cognito action.
+    confirm = mock_post.call_args_list[2]
+    assert confirm.kwargs["json"]["DeviceKey"] == "us-east-1_dev-1"
+    assert "DeviceSecretVerifierConfig" in confirm.kwargs["json"]
+    assert confirm.kwargs["headers"]["X-Amz-Target"].endswith("ConfirmDevice")
+
+    update = mock_post.call_args_list[3]
+    assert update.kwargs["json"]["DeviceRememberedStatus"] == "remembered"
+    assert update.kwargs["headers"]["X-Amz-Target"].endswith("UpdateDeviceStatus")
+
+
+@patch("drone_mobile.auth.requests.post")
+def test_confirm_failure_does_not_break_login(mock_post, tmp_path, totp_challenge_sub, tokens_with_device):
+    """A ConfirmDevice rejection is swallowed: the user still gets logged in."""
+    mock_post.side_effect = [
+        _resp(200, totp_challenge_sub),
+        _resp(200, tokens_with_device),
+        _resp(400, {"__type": "InvalidParameterException", "message": "Invalid device key given."}),
+    ]
+    auth = AuthenticationManager(
+        "user@example.com", "pw", token_dir=tmp_path, mfa_callback=lambda _c: "123456"
+    )
+
+    token = auth.authenticate()
+
+    assert token.access_token == "at"
+    assert not auth.device_file.exists()
+
+
+# ---------------------------------------------------------------------------
+# Device SRP re-auth (no MFA)
+# ---------------------------------------------------------------------------
+
+
+def _seed_device(auth):
+    auth._device = {
+        "DeviceKey": "us-east-1_dev-1",
+        "DeviceGroupKey": "-grp1",
+        "DevicePassword": "ZGV2aWNlLXBhc3N3b3Jk",
+    }
+    auth._save_device()
+
+
+@patch("drone_mobile.auth.requests.post")
+def test_new_auth_sends_device_key(mock_post, tmp_path, plain_tokens):
+    """When a device is remembered, InitiateAuth carries DEVICE_KEY."""
+    # No challenge here; return tokens directly so we only assert the request shape.
+    auth = AuthenticationManager("user@example.com", "pw", token_dir=tmp_path)
+    _seed_device(auth)
+    mock_post.return_value = _resp(200, plain_tokens)
+
+    auth.authenticate(force_refresh=True)
+
+    init_payload = mock_post.call_args_list[0].kwargs["json"]
+    assert init_payload["AuthParameters"]["DEVICE_KEY"] == "us-east-1_dev-1"
+
+
+@patch("drone_mobile.auth.requests.post")
+def test_device_srp_login_skips_mfa(mock_post, tmp_path, plain_tokens):
+    auth = AuthenticationManager(
+        "user@example.com", "pw", token_dir=tmp_path, mfa_callback=_fail_mfa
+    )
+    _seed_device(auth)
+
+    device_srp = {
+        "ChallengeName": "DEVICE_SRP_AUTH",
+        "Session": "sess-d",
+        "ChallengeParameters": {"USERNAME": "sub-uuid-123"},
+    }
+    password_verifier = {
+        "ChallengeName": "DEVICE_PASSWORD_VERIFIER",
+        "Session": "sess-d2",
+        "ChallengeParameters": {
+            "SRP_B": format((_BIG_N // 2) + 1234567, "x"),
+            "SALT": "0a1b2c3d",
+            "SECRET_BLOCK": "c2VjcmV0LWJsb2Nr",
+        },
+    }
+    mock_post.side_effect = [
+        _resp(200, device_srp),         # InitiateAuth -> DEVICE_SRP_AUTH
+        _resp(200, password_verifier),  # DEVICE_SRP_AUTH -> DEVICE_PASSWORD_VERIFIER
+        _resp(200, plain_tokens),       # DEVICE_PASSWORD_VERIFIER -> tokens
+    ]
+
+    token = auth.authenticate(force_refresh=True)
+
+    assert token.access_token == "at"
+    assert mock_post.call_args_list[1].kwargs["json"]["ChallengeName"] == "DEVICE_SRP_AUTH"
+    final = mock_post.call_args_list[2].kwargs["json"]
+    assert final["ChallengeName"] == "DEVICE_PASSWORD_VERIFIER"
+    assert final["ChallengeResponses"]["DEVICE_KEY"] == "us-east-1_dev-1"
+    assert "PASSWORD_CLAIM_SIGNATURE" in final["ChallengeResponses"]
+    assert auth.device_file.exists()  # still remembered
+
+
+@patch("drone_mobile.auth.requests.post")
+def test_device_srp_failure_clears_device(mock_post, tmp_path):
+    auth = AuthenticationManager(
+        "user@example.com", "pw", token_dir=tmp_path, mfa_callback=lambda _c: "123456"
+    )
+    _seed_device(auth)
+    assert auth.device_file.exists()
+
+    device_srp = {
+        "ChallengeName": "DEVICE_SRP_AUTH",
+        "Session": "s",
+        "ChallengeParameters": {"USERNAME": "sub"},
+    }
+    mock_post.side_effect = [
+        _resp(200, device_srp),  # InitiateAuth -> DEVICE_SRP_AUTH
+        _resp(400, {"__type": "NotAuthorizedException", "message": "Device not found"}),
+    ]
+
+    with pytest.raises(AuthenticationError):
+        auth.authenticate(force_refresh=True)
+
+    assert not auth.device_file.exists()
+    assert auth._device is None
+
+
+# ---------------------------------------------------------------------------
+# Refresh carries the device key
+# ---------------------------------------------------------------------------
+
+
+@patch("drone_mobile.auth.requests.post")
+def test_refresh_includes_device_key(mock_post, tmp_path):
+    auth = AuthenticationManager("user@example.com", "pw", token_dir=tmp_path)
+    _seed_device(auth)
+    auth._token = AuthToken(
+        access_token="at",
+        id_token="it",
+        refresh_token="rt",
+        token_type="Bearer",
+        expires_at=datetime.now() - timedelta(minutes=1),
+    )
+    mock_post.return_value = _resp(
+        200,
+        {
+            "AuthenticationResult": {
+                "AccessToken": "at2",
+                "IdToken": "it2",
+                "TokenType": "Bearer",
+                "ExpiresIn": 3600,
+            }
+        },
+    )
+
+    auth._refresh_token()
+
+    payload = mock_post.call_args_list[0].kwargs["json"]
+    assert payload["AuthParameters"]["REFRESH_TOKEN"] == "rt"
+    assert payload["AuthParameters"]["DEVICE_KEY"] == "us-east-1_dev-1"

--- a/tests/test_device_srp.py
+++ b/tests/test_device_srp.py
@@ -1,0 +1,149 @@
+"""Tests for the device SRP helpers (Cognito "remember this device").
+
+The headline test is a full SRP round trip: we register a device verifier the
+same way ``ConfirmDevice`` would, then play the role of the Cognito server and
+check that :class:`DeviceSRP` derives the identical session key (and therefore
+the identical ``PASSWORD_CLAIM_SIGNATURE``). This proves the client side of the
+exchange is correct against the SRP protocol itself, with no external reference
+implementation and no network.
+"""
+
+import base64
+import hashlib
+import hmac
+import os
+import re
+
+import pytest
+
+from drone_mobile.device_srp import (
+    _BIG_N,
+    _G,
+    _K,
+    _hex_hash,
+    _hkdf,
+    _pad_hex,
+    DeviceSRP,
+    cognito_timestamp,
+    generate_device_verifier,
+)
+
+DGK = "-GROUPKEY1"
+DK = "us-east-1_11111111-2222-3333-4444-555555555555"
+
+
+# ---------------------------------------------------------------------------
+# generate_device_verifier (ConfirmDevice registration secret)
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateDeviceVerifier:
+    def test_shape(self):
+        password, config = generate_device_verifier(DGK, DK)
+        assert isinstance(password, str) and password
+        assert set(config) == {"PasswordVerifier", "Salt"}
+        verifier = base64.standard_b64decode(config["PasswordVerifier"])
+        salt = base64.standard_b64decode(config["Salt"])
+        # 3072-bit modulus -> 384-byte verifier (385 with the leading-zero pad).
+        assert len(verifier) in (384, 385)
+        assert len(salt) in (16, 17)
+
+    def test_randomized(self):
+        _, a = generate_device_verifier(DGK, DK)
+        _, b = generate_device_verifier(DGK, DK)
+        assert a["PasswordVerifier"] != b["PasswordVerifier"]
+        assert a["Salt"] != b["Salt"]
+
+
+# ---------------------------------------------------------------------------
+# cognito_timestamp
+# ---------------------------------------------------------------------------
+
+
+class TestCognitoTimestamp:
+    def test_format(self):
+        ts = cognito_timestamp()
+        # e.g. "Tue Jun 5 09:08:07 UTC 2026" - day is NOT zero-padded.
+        assert re.match(
+            r"^(Mon|Tue|Wed|Thu|Fri|Sat|Sun) "
+            r"(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) "
+            r"\d{1,2} \d{2}:\d{2}:\d{2} UTC \d{4}$",
+            ts,
+        ), ts
+
+    def test_day_not_zero_padded(self):
+        # The day field must never carry a leading zero (Cognito rejects the
+        # signature otherwise). Verify the token between the month and time.
+        day_field = cognito_timestamp().split()[2]
+        assert not (len(day_field) == 2 and day_field[0] == "0")
+
+
+# ---------------------------------------------------------------------------
+# DeviceSRP
+# ---------------------------------------------------------------------------
+
+
+class TestDeviceSRP:
+    def test_srp_a_is_valid_public_value(self):
+        srp = DeviceSRP(DGK, DK, "device-password")
+        a = int(srp.srp_a, 16)
+        assert 0 < a < _BIG_N
+
+    def test_roundtrip_matches_server(self):
+        """Client derives the same signature the Cognito server would expect."""
+        # 1. Register the device verifier (what ConfirmDevice stores).
+        device_password, config = generate_device_verifier(DGK, DK)
+        salt_hex = base64.standard_b64decode(config["Salt"]).hex()
+        verifier = int.from_bytes(base64.standard_b64decode(config["PasswordVerifier"]), "big")
+
+        # 2. Client starts the device SRP exchange.
+        srp = DeviceSRP(DGK, DK, device_password)
+        big_a = int(srp.srp_a, 16)
+
+        # 3. Server picks a random b and sends B = (k*v + g^b) mod N.
+        b = int.from_bytes(os.urandom(32), "big") % _BIG_N
+        big_b = (_K * verifier + pow(_G, b, _BIG_N)) % _BIG_N
+        secret_block = base64.standard_b64encode(os.urandom(64)).decode()
+        timestamp = cognito_timestamp()
+
+        signature = srp.process_challenge(
+            format(big_b, "x"), salt_hex, secret_block, timestamp
+        )
+
+        # 4. Server independently derives S = (A * v^u)^b and the signature.
+        u = int(_hex_hash(_pad_hex(big_a) + _pad_hex(big_b)), 16)
+        s_server = pow((big_a * pow(verifier, u, _BIG_N)) % _BIG_N, b, _BIG_N)
+        key_server = _hkdf(
+            bytes.fromhex(_pad_hex(s_server)), bytes.fromhex(_pad_hex(u))
+        )
+        message = (
+            DGK.encode()
+            + DK.encode()
+            + base64.standard_b64decode(secret_block)
+            + timestamp.encode()
+        )
+        expected = base64.standard_b64encode(
+            hmac.new(key_server, message, hashlib.sha256).digest()
+        ).decode()
+
+        assert signature == expected
+
+    def test_rejects_zero_b(self):
+        srp = DeviceSRP(DGK, DK, "device-password")
+        with pytest.raises(ValueError, match="B mod N"):
+            srp.process_challenge(
+                format(_BIG_N, "x"),  # B == N -> B mod N == 0
+                "0a1b",
+                base64.standard_b64encode(b"x").decode(),
+                cognito_timestamp(),
+            )
+
+    def test_signature_is_32_byte_hmac(self):
+        srp = DeviceSRP(DGK, DK, "device-password")
+        sig = srp.process_challenge(
+            format((_BIG_N // 3) + 7, "x"),
+            "0a1b2c3d",
+            base64.standard_b64encode(os.urandom(48)).decode(),
+            cognito_timestamp(),
+        )
+        assert len(base64.standard_b64decode(sig)) == 32


### PR DESCRIPTION
## Problem

On accounts with MFA enabled (SMS or authenticator app), the library stops working every few hours and has to be re-authenticated with a fresh MFA code.

The Cognito refresh token issued for this app client expires after a few hours. When it expires, the library falls back to a full `USER_PASSWORD_AUTH` login, which returns an MFA challenge. In an unattended context (e.g. a Home Assistant coordinator) there is no one to type a code, so authentication fails until the user manually re-auths.

## Fix

Implement Cognito device remembering (the same "don't ask again on this device" the mobile app uses), in three parts:

1. **Use the pool's internal username in the MFA challenge response.** `RespondToAuthChallenge` now echoes `ChallengeParameters.USER_ID_FOR_SRP` (the `sub`) as `USERNAME` instead of the email alias. With the email, tokens are still issued but they cannot call `ConfirmDevice` (Cognito returns `InvalidParameterException: Invalid device key given`), which silently breaks device remembering. Pools that omit the parameter fall back to the configured username, so SMS-only setups are unaffected.

2. **Confirm and remember the device after login.** When Cognito returns `NewDeviceMetadata`, the library generates the device SRP verifier, calls `ConfirmDevice` + `UpdateDeviceStatus` (`remembered`), and persists `DeviceKey` / `DeviceGroupKey` / device password to `device.json` (mode `600`) next to `token.json`. `DEVICE_KEY` is also sent on token refresh.

3. **Re-authenticate via device SRP, no MFA.** Once the refresh token expires, the full login now passes `DEVICE_KEY`, so Cognito issues a `DEVICE_SRP_AUTH` challenge instead of MFA. The new `DeviceSRP` helper answers the `DEVICE_SRP_AUTH` -> `DEVICE_PASSWORD_VERIFIER` handshake and returns tokens with no second factor. If the handshake is rejected (revoked / rotated device), the stored device is cleared so the next attempt falls back to a clean login.

## New module

`drone_mobile/device_srp.py` implements the Cognito device SRP scheme (3072-bit group, SHA-256), matching `amazon-cognito-identity-js`: `generate_device_verifier` (registration) plus `DeviceSRP` and `cognito_timestamp` (authentication).

## Testing

- Verified end to end against a live DroneMobile account on Home Assistant OS: after deleting the cached token, the integration re-authenticates with zero MFA via `DEVICE_SRP_AUTH`.
- `tests/test_device_srp.py`: a self-contained SRP **round trip**, register a verifier the way `ConfirmDevice` does, then play the Cognito server and assert `DeviceSRP` derives the identical session key and signature. Plus verifier shape, timestamp format, and error guards.
- `tests/test_device_remembering.py`: the internal-username fix, confirm-and-remember flow, `DEVICE_SRP_AUTH` re-auth without MFA, stale-device cleanup, and `DEVICE_KEY` on refresh.
- The existing `tests/test_auth.py` MFA suite still passes (the SMS fixture's `USER_ID_FOR_SRP` equals the email, so the username change is transparent there).

## Notes

- `device.json` / `token.json` live in the configured `token_dir` (default `~/.config/drone_mobile`). For Home Assistant, the integration should point `token_dir` at `/config` so the remembered device survives Core updates; that is a separate integration-side change.
- Two pre-existing tests in `test_models.py` / `test_client.py` (`VehicleStatus.is_running` parsing) fail on `master` independently of this change.
