### PR TITLE
ci: update actions off deprecated Node 20 runtime, run tests on master

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -21,9 +21,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
     - name: Set up Python
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v6
       with:
         python-version: '3.x'
     - name: Install dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,9 @@ name: Tests
 
 on:
   push:
-    branches: [ main, develop ]
+    branches: [ master, develop ]
   pull_request:
-    branches: [ main, develop ]
+    branches: [ master, develop ]
 
 permissions:
   contents: read

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,10 +19,10 @@ jobs:
         python-version: ["3.10", "3.11", "3.12"]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
         cache: 'pip'
@@ -50,10 +50,10 @@ jobs:
         pytest --cov=drone_mobile --cov-report=xml --cov-report=term-missing
 
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v6
       if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.11'
       with:
-        file: ./coverage.xml
+        files: ./coverage.xml
         flags: unittests
         name: codecov-umbrella
         fail_ci_if_error: false
@@ -61,10 +61,10 @@ jobs:
   security:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
         python-version: "3.11"
 


### PR DESCRIPTION
## What

CI maintenance, two small fixes to the workflows:

1. **Clear the deprecated Node 20 action runtime warning.** Bump to the current latest majors (on a supported Node runtime):
   - `actions/checkout` v4 -> v6 (`test.yml`), v3 -> v6 (`python-publish.yml`)
   - `actions/setup-python` v4 -> v6 (`test.yml`), v3 -> v6 (`python-publish.yml`)
   - `codecov/codecov-action` v3 -> v6, and rename its deprecated `file:` input to `files:`
   - `pypa/gh-action-pypi-publish` is a Docker action (no Node), left as is.

2. **Run tests on `master`.** The triggers pointed at `main`/`develop`, but this repo's default branch is `master`, so the test job was not running on pushes or PRs to `master`. Repointed at `master` so CI actually gates changes.

## Why

GitHub now warns that the Node 20 action runtime is deprecated, and the test workflow was effectively dormant for `master`-targeted PRs.
